### PR TITLE
Fix kilo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 mille is a toy text editor in less than 1K lines of code (not including test codes). 
 It aims to be simple, readable codes, but works great.
-This project is inspired by [https://github.com/antirez/kilo](kilo). 
+This project is inspired by [kilo](https://github.com/antirez/kilo). 
 Moreover, mille doesn't depend on any external library. 
 
 ![demo](https://github.com/ad-sho-loko/mille/blob/master/img/demo.gif)


### PR DESCRIPTION
Noticed the link for kilo project in README 404'ed